### PR TITLE
remove Requires.private in pc file

### DIFF
--- a/src/mavsdk.pc.in
+++ b/src/mavsdk.pc.in
@@ -6,6 +6,5 @@ includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 Name: MAVSDK
 Description: API and library for MAVLink compatible systems written in C++17
 Version: @MAVSDK_VERSION_STRING@
-Requires.private: libcurl jsoncpp tinyxml2
 Libs: -L"${libdir}" -lmavsdk
 Cflags: -I"${includedir}" -I"${includedir}/mavsdk"


### PR DESCRIPTION
Requires.private lists the dependencies required for the library and not for the program.

+----------------+   +----------------+   +---------------+
| program        |-->| your lib       |-->| required lib  |
+----------------+   +----------------+   +---------------+

However in Yocto pkg-config reports dependencies as listed in Requires.private and causes build issues. Remove it for now to fix that.